### PR TITLE
[experiments/setup] Specify pyparsing's version

### DIFF
--- a/experiments/src/setup.py
+++ b/experiments/src/setup.py
@@ -30,7 +30,8 @@ setup(
         "pyzmq==16.0.2",
         "peakutils==1.3.2",
         "tabulate==0.8.1",
-        "kiwisolver==1.1.0"
+        "kiwisolver==1.1.0",
+        "pyparsing==2.4.7"
 
 
 # to use system packages


### PR DESCRIPTION
Otherwise, new versions of pyparsing (3.x) break the native installation.
Tested on:
- Native Debian
- Docker Ubuntu 18.04